### PR TITLE
Modified the word "screenshots" to [screenshots] and topics sequencing in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Dashboards topics :
 ## How to contribute?
 
 1. Pick one dashboard topic
-1. Analyze the corresponding example in the "screenshots" folder
-2. Create a sub-folder in "dashboards" and create start documenting the dashboard outline
-3. Develop the layout corresponding to the outline
-4. Make a commit at each new step of your build (one graph → on commit)
+2. Analyze the corresponding example in the "[screenshots]" folder
+3. Create a sub-folder in "dashboards" and create start documenting the dashboard outline
+4. Develop the layout corresponding to the outline
+5. Make a commit at each new step of your build (one graph → on commit)
 
 
 


### PR DESCRIPTION
This is all I have changed in the last section of the readme, which contains a section **How to contribute?**

_Where I have;_

- Modified the readme file by changing the word **"screenshots" to [screenshots]**.
- Corrected the number sequence of steps that were guiding the reader on what to do now.